### PR TITLE
Added iframe for the NYC hackathon live stream

### DIFF
--- a/hackathon.html
+++ b/hackathon.html
@@ -40,7 +40,15 @@ testimonials:
       <iframe frameborder=0 style='width:100%;height:500px' src="d4d-volunteer-map.html">
       </iframe>
 -->
-      <p>A live stream from the D4D Hackathon's NYC location will be available here on Saturday, April 1.</p>
+<iframe src="https://cdnapisec.kaltura.com/p/1674401/sp/167440100/embedIframeJs/uiconf_id/22908041/partner_id/1674401?iframeembed=true&playerId=kaltura_player_1443038339&entry_id=1_5rh8wk1t&flashvars[streamerType]=auto" width="560" height="395" allowfullscreen webkitallowfullscreen mozAllowFullScreen frameborder="0" style="width: 560px; height: 395px;" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
+<span itemprop="name" content="NYU Center for Data Science Live Stream v2"></span>
+<span itemprop="description" content="Live Stream"></span>
+<span itemprop="duration" content="0"></span>
+<span itemprop="thumbnail" content="http://cfvod.kaltura.com/p/1674401/sp/167440100/thumbnail/entry_id/1_5rh8wk1t/version/0/acv/11"></span>
+<span itemprop="width" content="560"></span>
+<span itemprop="height" content="395"></span>
+</iframe>
+      <p>A live stream from the D4D Hackathon's NYC location will be available here on Saturday, April 1 from 9:00-9:30 am (EDT) for the introductions and 8:00-9:00pm (EDT) for the showcase.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request adds the live stream for the NYC in-person event on Saturday to the website. 